### PR TITLE
Bugfix for "TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'" exception.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # flask-sqlacodegen
 
-GitHub page: [flask-sqlacodegen](https://github.com/ksindi/flask-sqlacodegen) 
+GitHub page: [flask-sqlacodegen](https://github.com/pwall27/flask-sqlacodegen)
 
 Fork of [sqlacodegen](https://pypi.python.org/pypi/sqlacodegen) by Alex Gronholm. Based off of version 1.1.6.
 
 What's different:
 
+* Bugfix for "TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
 * Support for Flask-SQLAlchemy syntax using `--flask` option.
 * Defaults to generating backrefs in relationships. `--nobackref` still included as option in case backrefs are not wanted. 
 * Naming of backrefs is class name in snake_case (as opposed to CamelCase) and is pluralized if it's Many-to-One or Many-to-Many using [inflect](https://pypi.python.org/pypi/inflect).
@@ -18,12 +19,12 @@ What's different:
 
 With pip:
 ```
-pip install flask-sqlacodegen
+pip install -e git://git@github.com:pwall27/flask-sqlacodegen.git#egg=flask-sqlacodegen
 ```
 
 Without pip:
 ```
-git clone https://github.com/ksindi/flask-sqlacodegen.git
+git clone https://github.com/pwall27/flask-sqlacodegen.git
 cd flask-sqlacodegen/
 python setup.py install
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Fork of [sqlacodegen](https://pypi.python.org/pypi/sqlacodegen) by Alex Gronholm
 
 What's different:
 
-* Bugfix for "TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
+* Bugfix for "TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'"
 * Support for Flask-SQLAlchemy syntax using `--flask` option.
 * Defaults to generating backrefs in relationships. `--nobackref` still included as option in case backrefs are not wanted. 
 * Naming of backrefs is class name in snake_case (as opposed to CamelCase) and is pluralized if it's Many-to-One or Many-to-Many using [inflect](https://pypi.python.org/pypi/inflect).

--- a/README.rst
+++ b/README.rst
@@ -2,13 +2,14 @@ flask-sqlacodegen
 =================
 
 GitHub page:
-`flask-sqlacodegen <https://github.com/ksindi/flask-sqlacodegen>`__
+`flask-sqlacodegen <https://github.com/pwall27/flask-sqlacodegen>`__
 
 Fork of `sqlacodegen <https://pypi.python.org/pypi/sqlacodegen>`__ by
 Alex Gronholm. Based off of version 1.1.6.
 
 What's different:
 
+-  Bugfix for "TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
 -  Support for Flask-SQLAlchemy syntax using ``--flask`` option.
 -  Defaults to generating backrefs in relationships. ``--nobackref``
    still included as option in case backrefs are not wanted.
@@ -32,13 +33,13 @@ With pip:
 
 ::
 
-    pip install flask-sqlacodegen
+    pip install -e git://git@github.com:pwall27/flask-sqlacodegen.git#egg=flask-sqlacodegen
 
 Without pip:
 
 ::
 
-    git clone https://github.com/ksindi/flask-sqlacodegen.git
+    git clone https://github.com/pwall27/flask-sqlacodegen.git
     cd flask-sqlacodegen/
     python setup.py install
 

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Alex Gronholm. Based off of version 1.1.6.
 
 What's different:
 
--  Bugfix for "TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
+-  Bugfix for "TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'"
 -  Support for Flask-SQLAlchemy syntax using ``--flask`` option.
 -  Defaults to generating backrefs in relationships. ``--nobackref``
    still included as option in case backrefs are not wanted.

--- a/sqlacodegen/codegen.py
+++ b/sqlacodegen/codegen.py
@@ -280,7 +280,7 @@ class ModelTable(Model):
 
     def render(self):
         met = ' metadata,' if _flask_prepend == '' else ''
-        text = 't_{0} = {1}Table(\n    {0!r},{2}\n'.format(self.table.name, _flask_prepend, met)
+        text = '{0}_table = {1}Table(\n    {0!r},{2}\n'.format(self.table.name, _flask_prepend, met)
 
         for column in self.table.columns:
             text += '    {0},\n'.format(_render_column(column, True))
@@ -498,7 +498,7 @@ class ManyToManyRelationship(Relationship):
     def __init__(self, source_cls, target_cls, assocation_table, inflect_engine):
         super(ManyToManyRelationship, self).__init__(source_cls, target_cls)
 
-        self.kwargs['secondary'] = repr(assocation_table.schema + '.' + assocation_table.name)
+        self.kwargs['secondary'] = repr(assocation_table.name)
         constraints = [c for c in assocation_table.constraints if isinstance(c, ForeignKeyConstraint)]
         constraints.sort(key=_get_constraint_sort_key)
         colname = _get_column_names(constraints[1])[0]


### PR DESCRIPTION
- Bugfix for "TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'" exception.
- Changed association_table prefix t_{0} to {0}_table