### PR TITLE
Encode output as utf-8 to match file header

### DIFF
--- a/sqlacodegen/codegen.py
+++ b/sqlacodegen/codegen.py
@@ -653,7 +653,8 @@ class CodeGenerator(object):
 
         # Render the model tables and classes
         for model in self.models:
-            print('\n\n' + model.render().rstrip('\n'), file=outfile)
+            print('\n\n', file=outfile)
+            print(model.render().rstrip('\n').encode('utf-8'), file=outfile)
 
         if self.footer:
             print(self.footer, file=outfile)


### PR DESCRIPTION
Hi. When running the SQLAlchemy model generator on databases that have non-ascii characters in the schema, it blows up. This change fixes that.

To reproduce, create a DB with some non-ascii characters, like:
```sql
CREATE TABLE test (
    units TEXT CHECK (units IN ('µs', 'ms', 's', 'm', 'h')) -- notice µs
);
```

Then, when running `flask-sqlacodegen` you should get:
```
Traceback (most recent call last):
  File "/Users/dave/dev/venv/bin/flask-sqlacodegen", line 11, in <module>
    sys.exit(main())
  File "/Users/dave/dev/venv/lib/python3.6/site-packages/sqlacodegen/main.py", line 60, in main
    generator.render(outfile)
  File "/Users/dave/dev/venv/lib/python3.6/site-packages/sqlacodegen/codegen.py", line 655, in render
    print('\n\n' + model.render().rstrip('\n'), file=outfile)
UnicodeEncodeError: 'ascii' codec can't encode character '\xb5' in position 170: ordinal not in range(128)
```

This can be avoided by invoking the command with `PYTHONIOENCODING=UTF-8 flask-sqlacodegen` but it's nicer to have it fixed at the source. Encoding the output as utf-8 is also more correct, since the [generated file header](https://github.com/ksindi/flask-sqlacodegen/blob/0d13bd9ef91536d87a776d49ad0d89001310cd8a/sqlacodegen/codegen.py#L525) already specifies `# coding: utf-8`.

HTH