### PR TITLE
decode rendered text before output

### DIFF
--- a/sqlacodegen/codegen.py
+++ b/sqlacodegen/codegen.py
@@ -670,7 +670,7 @@ class CodeGenerator(object):
         # Render the model tables and classes
         for model in self.models:
             print('\n\n', file=outfile)
-            print(model.render().rstrip('\n'), file=outfile)
+            print(model.render().rstrip('\n').decode("unicode-escape"), file=outfile)
 
         if self.footer:
             print(self.footer, file=outfile)

--- a/sqlacodegen/codegen.py
+++ b/sqlacodegen/codegen.py
@@ -670,7 +670,11 @@ class CodeGenerator(object):
         # Render the model tables and classes
         for model in self.models:
             print('\n\n', file=outfile)
-            print(model.render().rstrip('\n').decode("unicode-escape"), file=outfile)
+            if sys.version_info.major <= 2:
+                model_text = model.render().rstrip('\n').decode("unicode-escape")
+            else:
+                model_text = model.render().rstrip('\n')
+            print(model_text, file=outfile)
 
         if self.footer:
             print(self.footer, file=outfile)


### PR DESCRIPTION
The current program is not decoded before output. In the python2.x environment, if the user's table creation statement (such as comment) contains non-ascii characters, the output will be printed as unicode, which looks ugly:

```python
class DemoTable(db.Model):
    __tablename__ = 'demo_table'

    id = db.Column(db.BigInteger, primary_key=True, info=u'\u4e3b\u952e')
    gmt_create = db.Column(db.DateTime, nullable=False, server_default=db.FetchedValue(), info=u'\u521b\u5efa\u65f6\u95f4')
    gmt_modified = db.Column(db.DateTime, nullable=False, server_default=db.FetchedValue(), info=u'\u4fee\u6539\u65f6\u95f4')
```

This small commit can solve this problem.

```python
class DemoTable(db.Model):
    __tablename__ = 'demo_table'
    id = db.Column(db.BigInteger, primary_key=True, info=u'主键')
    gmt_create = db.Column(db.DateTime, nullable=False, server_default=db.FetchedValue(), info=u'创建时间')
    gmt_modified = db.Column(db.DateTime, nullable=False, server_default=db.FetchedValue(), info=u'修改时间')
```